### PR TITLE
Benchmark loading vector data directly fromMemorySegment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgs>
+                      <arg>--enable-preview</arg>
                       <arg>--add-modules</arg><arg>jdk.incubator.vector</arg>
                     </compilerArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.19</jmh.version>
-        <maven.compiler.source>20</maven.compiler.source>
-        <maven.compiler.target>20</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/testing/FloatDotProductBenchmark.java
+++ b/src/main/java/testing/FloatDotProductBenchmark.java
@@ -51,7 +51,7 @@ public class FloatDotProductBenchmark {
     Path p2 = Path.of("vector2.data");
     try (FileChannel fc1 = FileChannel.open(p1, CREATE, READ, WRITE);
          FileChannel fc2 = FileChannel.open(p2, CREATE, READ, WRITE)) {
-      Arena arena = Arena.openShared();
+      Arena arena = Arena.global();
       ByteBuffer buf = ByteBuffer.allocate(size * 2 * Float.BYTES);
       buf.order(LITTLE_ENDIAN);
       buf.asFloatBuffer().put(0, tmpA);
@@ -62,7 +62,7 @@ public class FloatDotProductBenchmark {
       if (n != size * 2 * Float.BYTES) {
         throw new AssertionError("expected n=" + size * 2 * Float.BYTES + ", got:" + n);
       }
-      alignedSegment = fc1.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES, arena.scope());
+      alignedSegment = fc1.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES, arena);
 
       // create the file/segment with unaligned data
       n = fc2.write(ByteBuffer.wrap(new byte[] { 0x00 }));
@@ -73,7 +73,7 @@ public class FloatDotProductBenchmark {
       if (n != size * 2 * Float.BYTES) {
         throw new AssertionError("expected n=" + size * 2 * Float.BYTES + ", got:" + n);
       }
-      unalignedSegment = fc2.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES + 1, arena.scope());
+      unalignedSegment = fc2.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES + 1, arena);
     }
 
     // Thread local buffers
@@ -294,5 +294,11 @@ public class FloatDotProductBenchmark {
               + b[i + 7] * a[i + 7];
     }
     return res;
+  }
+
+  public static void main(String... args) throws Exception {
+    var x = new FloatDotProductBenchmark();
+    x.size = 1024; // 1024;
+    x.init();
   }
 }

--- a/src/main/java/testing/FloatDotProductBenchmark.java
+++ b/src/main/java/testing/FloatDotProductBenchmark.java
@@ -53,11 +53,17 @@ public class FloatDotProductBenchmark {
       buf.order(LITTLE_ENDIAN);
       buf.asFloatBuffer().put(0, tmpA);
       buf.asFloatBuffer().put(size, tmpB);
-      int n = fc.write(buf);
-      assert n == size * 2 * Float.BYTES;
+      int n = fc.write(ByteBuffer.wrap(new byte[] { 0x00 }));
+      if (n != 1) {
+        throw new AssertionError("expected n=1, got:" + n);
+      }
+      n = fc.write(buf);
+      if (n != size * 2 * Float.BYTES) {
+        throw new AssertionError("expected n=" + size * 2 * Float.BYTES + ", got:" + n);
+      }
 
       Arena arena = Arena.openShared();
-      segment = fc.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES, arena.scope());
+      segment = fc.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES + 1, arena.scope());
     }
 
     // Thread local buffers
@@ -131,7 +137,7 @@ public class FloatDotProductBenchmark {
 
   @Benchmark
   public float dotProductFromMemorySegment() {
-    return dotProductFromMemorySegment(0, size * Float.BYTES);
+    return dotProductFromMemorySegment(1, size * Float.BYTES + 1);
   }
 
   private float dotProductFromMemorySegment(long segmentOffset1, long segmentOffset2) {

--- a/src/main/java/testing/FloatDotProductBenchmark.java
+++ b/src/main/java/testing/FloatDotProductBenchmark.java
@@ -72,7 +72,7 @@ public class FloatDotProductBenchmark {
 
     float f1 = dotProductCopyFromArray();
     float f2 = dotProductFromMemorySegment();
-    if (Math.abs(f1 - f2) > 0.0001) {
+    if (Math.abs(f1 - f2) > 0.0001 || Float.isNaN(Math.abs(f1 - f2))) {
       throw new AssertionError(f1 + " != " + f2);
     }
   }
@@ -86,8 +86,8 @@ public class FloatDotProductBenchmark {
   public float dotProductCopyFromArray() {
     // loads vector data from the backing memory segment into the float arrays,
     // in the same way as that of Lucene's MemorySegmentIndexInput.
-    MemorySegment.copy(segment, LAYOUT_LE_FLOAT, 0, a, 0, size);
-    MemorySegment.copy(segment, LAYOUT_LE_FLOAT, (long) size * Float.BYTES, b, 0, size);
+    MemorySegment.copy(segment, LAYOUT_LE_FLOAT, 1, a, 0, size);
+    MemorySegment.copy(segment, LAYOUT_LE_FLOAT, (long) size * Float.BYTES + 1, b, 0, size);
 
     if (a.length != b.length) {
       throw new IllegalArgumentException("vector dimensions differ: " + a.length + "!=" + b.length);

--- a/src/main/java/testing/MSReadAlignment.java
+++ b/src/main/java/testing/MSReadAlignment.java
@@ -1,0 +1,102 @@
+package testing;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.file.StandardOpenOption.*;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 3, time = 3)
+@Fork(value = 1, jvmArgsPrepend = {"--enable-preview"})
+public class MSReadAlignment {
+
+    private float[] a, b;
+
+    private MemorySegment segment;
+
+    @Param({"1", "4", "6", "8", "13", "16", "25", "32", "64", "100", "128", "207", "256", "300", "512", "702", "1024"})
+    //@Param({"1", "4", "6", "8", "13", "16", "25", "32", "64", "100" })
+    //@Param({"702", "1024"})
+    //@Param({"16", "32", "64"})
+    int size;
+
+    @Setup(Level.Trial)
+    public void init() throws IOException {
+        float[] tmpA = new float[size];
+        float[] tmpB = new float[size];
+        for (int i = 0; i < size; ++i) {
+            tmpA[i] = ThreadLocalRandom.current().nextFloat();
+            tmpB[i] = ThreadLocalRandom.current().nextFloat();
+        }
+        Path p = Path.of("vector.data");
+        try (FileChannel fc = FileChannel.open(p, CREATE, READ, WRITE)) {
+            ByteBuffer buf = ByteBuffer.allocate(size * 2 * Float.BYTES);
+            buf.order(LITTLE_ENDIAN);
+            buf.asFloatBuffer().put(0, tmpA);
+            buf.asFloatBuffer().put(size, tmpB);
+            int n = fc.write(ByteBuffer.wrap(new byte[] { 0x00 }));
+            if (n != 1) {
+                throw new AssertionError("expected n=1, got:" + n);
+            }
+            n = fc.write(buf);
+            if (n != size * 2 * Float.BYTES) {
+                throw new AssertionError("expected n=" + size * 2 * Float.BYTES + ", got:" + n);
+            }
+
+            Arena arena = Arena.global();
+            segment = fc.map(FileChannel.MapMode.READ_ONLY, 0, size * 2L * Float.BYTES + 1, arena);
+        }
+
+        // Thread local buffers
+        a = new float[size];
+        b = new float[size];
+
+//        float[] f1 = readAligned();
+//        float[] f2 = readUnaligned();
+//        if (Arrays.equals(f1, f2) == false) {
+//            throw new AssertionError("arrays not equal:\n" + Arrays.toString(f1) + "\n" + Arrays.toString(f2));
+//        }
+    }
+
+
+    static final ValueLayout.OfFloat LAYOUT_LE_FLOAT =
+            ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+    static final ValueLayout.OfFloat LAYOUT_LE_FLOAT_UNALIGNED =
+            ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+    @Benchmark
+    public float[] readAligned() {
+        MemorySegment.copy(segment, LAYOUT_LE_FLOAT, 0, a, 0, size);
+        return a;
+    }
+
+    @Benchmark
+    public float[] readUnaligned() {
+        MemorySegment.copy(segment, LAYOUT_LE_FLOAT_UNALIGNED, 1, b, 0, size);
+        return b;
+    }
+
+    public static void main(String... args) throws Exception {
+        var x = new MSReadAlignment();
+        x.size = 1024;
+        x.init();
+        x.readAligned();
+        x.readUnaligned();
+    }
+}


### PR DESCRIPTION
Benchmark loading vector data directly fromMemorySegment. Only Float dotProduct has been updated, and just for experimentation purposes.